### PR TITLE
Implement Bot Admin-only functionality

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,6 +6,7 @@ MONGO_URI="mongodb://127.0.0.1:100"
 
 # needed by ./bot
 DISCORD_TOKEN=""
+BOT_ADMINS=""
 
 # needed by ./portal
 PORT=80

--- a/bot/main.py
+++ b/bot/main.py
@@ -65,6 +65,7 @@ class CheckFailedException(commands.CommandError):
 
     def __init__(self, check_name):
         """Initialise with the name of the check."""
+        super().__init__()
         self.check_name = check_name
 
 
@@ -82,16 +83,16 @@ def is_verified(user_id):
     return True if get_users_from_discordid(user_id) else False
 
 
-def is_bot_admin(userID: str):
+def is_bot_admin(user_id: str):
     """Checks if the user with the given discord ID is a bot admin or not."""
-    return userID in BOT_ADMINS
+    return user_id in BOT_ADMINS
 
 
 def is_author_bot_admin(ctx: commands.Context):
     """Wrapper function for `is_bot_admin`; checks if the user who invoked the command
     is a bot admin or not."""
-    userID = ctx.message.author.id
-    if not is_bot_admin(str(userID)):
+    user_id = ctx.message.author.id
+    if not is_bot_admin(str(user_id)):
         raise CheckFailedException("is_author_bot_admin")
     return True
 
@@ -232,7 +233,6 @@ async def verify_user(ctx):
 async def backend_info(ctx):
     """For debugging server info; sends details of the server."""
 
-    authorID = str(ctx.message.author.id)
     uname = platform.uname()
     await ctx.send(
         f"Here are the server details:\n"
@@ -248,8 +248,8 @@ async def backend_info(ctx):
 async def backend_info_error(ctx, error):
     """If the author of the message is not a bot admin then reply accordingly."""
     if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_author_bot_admin":
-        authorID = str(ctx.message.author.id)
-        await ctx.reply(f"{authorID} is not a bot admin.")
+        author_id = str(ctx.message.author.id)
+        await ctx.reply(f"{author_id} is not a bot admin.")
     else:
         await ctx.reply("Some check failed.")
 
@@ -257,10 +257,10 @@ async def backend_info_error(ctx, error):
 def is_academic_or_bot_admin(ctx: commands.Context):
     """Checks if the server is an academic server or if the author is a bot admin."""
     server_config = get_config(str(ctx.guild.id))
-    userID = ctx.message.author.id
+    user_id = ctx.message.author.id
 
     if server_config is None:
-        if not is_bot_admin(str(userID)):
+        if not is_bot_admin(str(user_id)):
             raise CheckFailedException("is_academic_or_bot_admin")
     return server_config.get("is_academic", False)
 
@@ -293,8 +293,8 @@ async def query_error(ctx, error):
     admin, replies with error message.
     """
     if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
-        authorID = str(ctx.message.author.id)
-        await ctx.reply(f"This server is not for academic purposes and {authorID} is not a bot admin.")
+        author_id = str(ctx.message.author.id)
+        await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
     else:
         await ctx.reply("Some check failed.")
 
@@ -329,8 +329,8 @@ async def roll_error(ctx, error):
     replies with error message.
     """
     if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
-        authorID = str(ctx.message.author.id)
-        await ctx.reply(f"This server is not for academic purposes and {authorID} is not a bot admin.")
+        author_id = str(ctx.message.author.id)
+        await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
     else:
         await ctx.reply("Some check failed.")
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -212,7 +212,7 @@ async def verify_user(ctx):
 @bot.command(name="backend_info")
 async def backend_info(ctx):
     """For debugging server info; sends details of the server."""
-    
+
     authorID = str(ctx.message.author.id)
     if is_bot_admin(authorID):
         uname = platform.uname()

--- a/bot/main.py
+++ b/bot/main.py
@@ -54,6 +54,7 @@ db: database.Database = None  # assigned in main function
 
 class CheckFailedException(commands.CommandError):
     """Custom exception to help identify which check function failed."""
+
     def __init__(self, check_name):
         """Initialise with the name of the check."""
         self.check_name = check_name

--- a/bot/main.py
+++ b/bot/main.py
@@ -212,15 +212,20 @@ async def verify_user(ctx):
 @bot.command(name="backend_info")
 async def backend_info(ctx):
     """For debugging server info; sends details of the server."""
-    uname = platform.uname()
-    await ctx.send(
-        f"Here are the server details:\n"
-        f"system: {uname.system}\n"
-        f"node: {uname.node}\n"
-        f"release: {uname.release}\n"
-        f"version: {uname.version}\n"
-        f"machine: {uname.machine}"
-    )
+    
+    authorID = str(ctx.message.author.id)
+    if is_bot_admin(authorID):
+        uname = platform.uname()
+        await ctx.send(
+            f"Here are the server details:\n"
+            f"system: {uname.system}\n"
+            f"node: {uname.node}\n"
+            f"release: {uname.release}\n"
+            f"version: {uname.version}\n"
+            f"machine: {uname.machine}"
+        )
+    else:
+        await ctx.reply(f"{authorID} is not a bot admin.")
 
 
 def is_academic(ctx: commands.Context):

--- a/bot/main.py
+++ b/bot/main.py
@@ -52,6 +52,13 @@ bot = commands.Bot(command_prefix=".")
 db: database.Database = None  # assigned in main function
 
 
+class CheckFailedException(commands.CommandError):
+    """Custom exception to help identify which check function failed."""
+    def __init__(self, check_name):
+        """Initialise with the name of the check."""
+        self.check_name = check_name
+
+
 def get_users_from_discordid(user_id):
     """
     Finds users from the database, given their ID and returns
@@ -75,7 +82,9 @@ def is_author_bot_admin(ctx: commands.Context):
     """Wrapper function for `is_bot_admin`; checks if the user who invoked the command
     is a bot admin or not."""
     userID = ctx.message.author.id
-    return is_bot_admin(str(userID))
+    if not is_bot_admin(str(userID)):
+        raise CheckFailedException("is_author_bot_admin")
+    return True
 
 
 def get_realname_from_discordid(user_id):
@@ -233,7 +242,7 @@ def is_academic(ctx: commands.Context):
     server_config = get_config(str(ctx.guild.id))
 
     if server_config is None:
-        return False
+        raise CheckFailedException("is_academic")
     return server_config.get("is_academic", False)
 
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -260,9 +260,10 @@ def is_academic_or_bot_admin(ctx: commands.Context):
     user_id = ctx.message.author.id
 
     if server_config is None:
-        if not is_bot_admin(str(user_id)):
-            raise CheckFailedException("is_academic_or_bot_admin")
-    return server_config.get("is_academic", False)
+        return False
+    if not server_config.get("is_academic", False) and not is_bot_admin(str(user_id)):
+        raise CheckFailedException("is_academic_or_bot_admin")
+    return True
 
 
 @bot.command(name="query")

--- a/bot/main.py
+++ b/bot/main.py
@@ -4,8 +4,10 @@ etc. are defined, as well the bot commands and a main routine.
 
 This module defines the following functions.
 
-- `get_users_from_discordid()`: Find users from DB given user ID
-- `is_verified()`: If a user is present in DB or not
+- `get_users_from_discordid()`: Find users from DB given user ID.
+- `is_verified()`: If a user is present in DB or not.
+- `is_bot_admin()`: If a user is a bot admin or not.
+- `is_author_bot_admin()`: If the author of the message is a bot admin or not.
 - `get_realname_from_discordid()`: Get a user's real name from their Discord ID.
 - `send_link()`: Send link for reattempting authentication.
 - `get_config()`: Gives the config object for a given server.
@@ -15,14 +17,20 @@ This module defines the following functions.
 - `set_nickname()`: Sets nickname of the given user to real name if server specifies.
 - `post_verification()`: Handle role add/delete and nickname set post-verification of given user.
 - `verify_user()`: Implements `.verify`.
-- `backend_info()`: Logs server details for debug purposes
-- `is_academic()`: Checks if server is for academic use.
-- `query()`: Returns user details, uses Discord ID to find in DB.
-- `query_error()`: Replies eror message if server is not academic.
-- `roll()`: Returns user details, uses roll number to find in DB.
-- `roll_error()`: Replies eror message if server is not academic.
+- `backend_info()`: Logs server details for debug purposes (bot admin only).
+- `backend_info_error()`: Replies with error message is user is not a bot admin.
+- `is_academic_or_bot_admin()`: Checks if server is for academic use or if the 
+    author of the message is a bot admin or not.
+- `query()`: Returns user details, uses Discord ID to find in DB (bot admin-able).
+- `query_error()`: Replies eror message if server is not academic and the user is not a bot admin.
+- `roll()`: Returns user details, uses roll number to find in DB (bot admin-able).
+- `roll_error()`: Replies eror message if server is not academic and the user is not a bot admin.
 - `on_ready()`: Logs a message when the bot joins a server.
 - `main()`: Reads server config, loads DB and starts bot.
+
+The module defines the following class:
+
+- `CheckFailedException`: to be able to identify what exact check function failed.
 
 """
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -66,6 +66,11 @@ def is_verified(user_id):
     return True if get_users_from_discordid(user_id) else False
 
 
+def is_bot_admin(userID: str):
+    """Checks if the user with the given discord ID is a bot admin or not."""
+    return userID in BOT_ADMINS
+
+
 def get_realname_from_discordid(user_id):
     """Returns the real name of the first user who matches the given ID."""
     users = get_users_from_discordid(user_id)

--- a/bot/main.py
+++ b/bot/main.py
@@ -53,7 +53,7 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 MONGO_DATABASE = os.getenv("MONGO_DATABASE")
 MONGO_URI = os.getenv("MONGO_URI")
 BASE_URL = os.getenv("BASE_URL")
-BOT_ADMINS = os.getenv("BOT_ADMINS").split(",")
+BOT_ADMINS = [int(id) for id in os.getenv("BOT_ADMINS").split(",")]
 SERVER_CONFIG = ConfigParser()
 
 bot = commands.Bot(command_prefix=".")
@@ -83,7 +83,7 @@ def is_verified(user_id):
     return True if get_users_from_discordid(user_id) else False
 
 
-def is_bot_admin(user_id: str):
+def is_bot_admin(user_id: int):
     """Checks if the user with the given discord ID is a bot admin or not."""
     return user_id in BOT_ADMINS
 
@@ -92,7 +92,7 @@ def is_author_bot_admin(ctx: commands.Context):
     """Wrapper function for `is_bot_admin`; checks if the user who invoked the command
     is a bot admin or not."""
     user_id = ctx.message.author.id
-    if not is_bot_admin(str(user_id)):
+    if not is_bot_admin(user_id):
         raise CheckFailedException("is_author_bot_admin")
     return True
 
@@ -248,7 +248,7 @@ async def backend_info(ctx):
 async def backend_info_error(ctx, error):
     """If the author of the message is not a bot admin then reply accordingly."""
     if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_author_bot_admin":
-        author_id = str(ctx.message.author.id)
+        author_id = ctx.message.author.id
         await ctx.reply(f"{author_id} is not a bot admin.")
     else:
         await ctx.reply("Some check failed.")
@@ -261,7 +261,7 @@ def is_academic_or_bot_admin(ctx: commands.Context):
 
     if server_config is None:
         return False
-    if not server_config.get("is_academic", False) and not is_bot_admin(str(user_id)):
+    if not server_config.get("is_academic", False) and not is_bot_admin(user_id):
         raise CheckFailedException("is_academic_or_bot_admin")
     return True
 
@@ -294,7 +294,7 @@ async def query_error(ctx, error):
     admin, replies with error message.
     """
     if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
-        author_id = str(ctx.message.author.id)
+        author_id = ctx.message.author.id
         await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
     else:
         await ctx.reply("Some check failed.")
@@ -330,7 +330,7 @@ async def roll_error(ctx, error):
     replies with error message.
     """
     if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
-        author_id = str(ctx.message.author.id)
+        author_id = ctx.message.author.id
         await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
     else:
         await ctx.reply("Some check failed.")

--- a/bot/main.py
+++ b/bot/main.py
@@ -247,7 +247,11 @@ async def backend_info(ctx):
 @backend_info.error
 async def backend_info_error(ctx, error):
     """If the author of the message is not a bot admin then reply accordingly."""
-    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_author_bot_admin":
+    if (
+        isinstance(error, commands.CheckFailure)
+        and isinstance(error.original, CheckFailedException)
+        and error.original.check_name == "is_author_bot_admin"
+    ):
         author_id = ctx.message.author.id
         await ctx.reply(f"{author_id} is not a bot admin.")
     else:
@@ -293,9 +297,15 @@ async def query_error(ctx, error):
     For the `query` command, if the server is not academic and the invoking user is not a bot
     admin, replies with error message.
     """
-    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
+    if (
+        isinstance(error, commands.CheckFailure)
+        and isinstance(error.original, CheckFailedException)
+        and error.original.check_name == "is_academic_or_bot_admin"
+    ):
         author_id = ctx.message.author.id
-        await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
+        await ctx.reply(
+            f"This server is not for academic purposes and {author_id} is not a bot admin."
+        )
     else:
         await ctx.reply("Some check failed.")
 
@@ -329,9 +339,15 @@ async def roll_error(ctx, error):
     For the `roll` command, if the server is not academic and the ivoking user is not a bot admin,
     replies with error message.
     """
-    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
+    if (
+        isinstance(error, commands.CheckFailure)
+        and isinstance(error.original, CheckFailedException)
+        and error.original.check_name == "is_academic_or_bot_admin"
+    ):
         author_id = ctx.message.author.id
-        await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
+        await ctx.reply(
+            f"This server is not for academic purposes and {author_id} is not a bot admin."
+        )
     else:
         await ctx.reply("Some check failed.")
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -45,6 +45,7 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 MONGO_DATABASE = os.getenv("MONGO_DATABASE")
 MONGO_URI = os.getenv("MONGO_URI")
 BASE_URL = os.getenv("BASE_URL")
+BOT_ADMINS = os.getenv("BOT_ADMINS").split(",")
 SERVER_CONFIG = ConfigParser()
 
 bot = commands.Bot(command_prefix=".")

--- a/bot/main.py
+++ b/bot/main.py
@@ -71,6 +71,13 @@ def is_bot_admin(userID: str):
     return userID in BOT_ADMINS
 
 
+def is_author_bot_admin(ctx: commands.Context):
+    """Wrapper function for `is_bot_admin`; checks if the user who invoked the command
+    is a bot admin or not."""
+    userID = ctx.message.author.id
+    return is_bot_admin(str(userID))
+
+
 def get_realname_from_discordid(user_id):
     """Returns the real name of the first user who matches the given ID."""
     users = get_users_from_discordid(user_id)

--- a/bot/main.py
+++ b/bot/main.py
@@ -220,22 +220,30 @@ async def verify_user(ctx):
 
 
 @bot.command(name="backend_info")
+@commands.check(is_author_bot_admin)
 async def backend_info(ctx):
     """For debugging server info; sends details of the server."""
 
     authorID = str(ctx.message.author.id)
-    if is_bot_admin(authorID):
-        uname = platform.uname()
-        await ctx.send(
-            f"Here are the server details:\n"
-            f"system: {uname.system}\n"
-            f"node: {uname.node}\n"
-            f"release: {uname.release}\n"
-            f"version: {uname.version}\n"
-            f"machine: {uname.machine}"
-        )
-    else:
+    uname = platform.uname()
+    await ctx.send(
+        f"Here are the server details:\n"
+        f"system: {uname.system}\n"
+        f"node: {uname.node}\n"
+        f"release: {uname.release}\n"
+        f"version: {uname.version}\n"
+        f"machine: {uname.machine}"
+    )
+
+
+@backend_info.error
+async def backend_info_error(ctx, error):
+    """If the author of the message is not a bot admin then reply accordingly."""
+    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_author_bot_admin":
+        authorID = str(ctx.message.author.id)
         await ctx.reply(f"{authorID} is not a bot admin.")
+    else:
+        await ctx.reply("Some checks failed.")
 
 
 def is_academic(ctx: commands.Context):

--- a/bot/main.py
+++ b/bot/main.py
@@ -19,7 +19,7 @@ This module defines the following functions.
 - `verify_user()`: Implements `.verify`.
 - `backend_info()`: Logs server details for debug purposes (bot admin only).
 - `backend_info_error()`: Replies with error message is user is not a bot admin.
-- `is_academic_or_bot_admin()`: Checks if server is for academic use or if the 
+- `is_academic_or_bot_admin()`: Checks if server is for academic use or if the
     author of the message is a bot admin or not.
 - `query()`: Returns user details, uses Discord ID to find in DB (bot admin-able).
 - `query_error()`: Replies eror message if server is not academic and the user is not a bot admin.
@@ -247,7 +247,11 @@ async def backend_info(ctx):
 @backend_info.error
 async def backend_info_error(ctx, error):
     """If the author of the message is not a bot admin then reply accordingly."""
-    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_author_bot_admin":
+    if (
+        isinstance(error, commands.CheckFailure)
+        and isinstance(error.original, CheckFailedException)
+        and error.original.check_name == "is_author_bot_admin"
+    ):
         author_id = str(ctx.message.author.id)
         await ctx.reply(f"{author_id} is not a bot admin.")
     else:
@@ -272,8 +276,8 @@ async def query(
     identifier: discord.User,
 ):
     """
-    First checks if the server is an academic one or if the user who invoked the 
-    command is a bot admin. If so, finds that user (by Discord ID) in the DB. 
+    First checks if the server is an academic one or if the user who invoked the
+    command is a bot admin. If so, finds that user (by Discord ID) in the DB.
     If present, replies with their name, email and roll number.
     Otherwise replies telling the user they are not registed with CAS.
     """
@@ -289,12 +293,18 @@ async def query(
 @query.error
 async def query_error(ctx, error):
     """
-    For the `query` command, if the server is not academic and the invoking user is not a bot 
+    For the `query` command, if the server is not academic and the invoking user is not a bot
     admin, replies with error message.
     """
-    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
+    if (
+        isinstance(error, commands.CheckFailure)
+        and isinstance(error.original, CheckFailedException)
+        and error.original.check_name == "is_academic_or_bot_admin"
+    ):
         author_id = str(ctx.message.author.id)
-        await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
+        await ctx.reply(
+            f"This server is not for academic purposes and {author_id} is not a bot admin."
+        )
     else:
         await ctx.reply("Some check failed.")
 
@@ -306,9 +316,9 @@ async def roll(
     identifier: int,
 ):
     """
-    First checks if the server is an academic one or if the user who invoked the 
-    command is a bot admin If so, finds that user in the DB. If present, replies 
-    with their name, email and roll number. Otherwise replies telling the user 
+    First checks if the server is an academic one or if the user who invoked the
+    command is a bot admin If so, finds that user in the DB. If present, replies
+    with their name, email and roll number. Otherwise replies telling the user
     they are not registed with CAS.
 
     Same as the `query` command, except this searches by roll number instead of Discord ID.
@@ -328,9 +338,15 @@ async def roll_error(ctx, error):
     For the `roll` command, if the server is not academic and the ivoking user is not a bot admin,
     replies with error message.
     """
-    if isinstance(error, commands.CheckFailure) and isinstance(error.original, CheckFailedException) and error.original.check_name == "is_academic_or_bot_admin":
+    if (
+        isinstance(error, commands.CheckFailure)
+        and isinstance(error.original, CheckFailedException)
+        and error.original.check_name == "is_academic_or_bot_admin"
+    ):
         author_id = str(ctx.message.author.id)
-        await ctx.reply(f"This server is not for academic purposes and {author_id} is not a bot admin.")
+        await ctx.reply(
+            f"This server is not for academic purposes and {author_id} is not a bot admin."
+        )
     else:
         await ctx.reply("Some check failed.")
 


### PR DESCRIPTION
This PR resolves 4 tasks out of the 6 listed in the issue.

1. Read discord IDs of admins that must be set in `.env` file.
2. Add a check function that checks if a given member ID is a bot admin.
3. Make `backend_info` an admin command.
5. Make query/role admin-able commands so that admins can run it outside the "academic server" constraint.

I've also added docstrings for the functions defined, and updated the module docstring with those functions.