### PR TITLE
Implement admin only commands and make some commands admin-able

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,7 @@ MONGO_URI="mongodb://127.0.0.1:100"
 
 # needed by ./bot
 DISCORD_TOKEN=""
+BOT_ADMINS=""
 
 # needed by ./portal
 CAS_LINK="https://cas.my-org.com/login"

--- a/bot/main.py
+++ b/bot/main.py
@@ -237,16 +237,21 @@ async def verify_user(ctx: commands.Context):
 @bot.hybrid_command(name="backend_info")
 async def backend_info(ctx: commands.Context):
     """For debugging server info; sends details of the server."""
-    uname = platform.uname()
-    await ctx.reply(
-        f"Here are the server details:\n"
-        f"system: {uname.system}\n"
-        f"node: {uname.node}\n"
-        f"release: {uname.release}\n"
-        f"version: {uname.version}\n"
-        f"machine: {uname.machine}",
-        ephemeral=True,
-    )
+
+    author = ctx.message.author
+    if is_bot_admin(author.id):
+        uname = platform.uname()
+        await ctx.reply(
+            f"Here are the server details:\n"
+            f"system: {uname.system}\n"
+            f"node: {uname.node}\n"
+            f"release: {uname.release}\n"
+            f"version: {uname.version}\n"
+            f"machine: {uname.machine}",
+            ephemeral=True,
+        )
+    else:
+        await ctx.reply(f"{author.id} is not a bot admin.", ephemeral=True)
 
 
 def is_academic(ctx: commands.Context):

--- a/bot/main.py
+++ b/bot/main.py
@@ -90,9 +90,18 @@ def is_verified(user_id: int):
     """Checks if any user with the given ID exists in the DB or not."""
     return True if get_users_from_discordid(user_id) else False
 
+
 def is_bot_admin(user_id: int):
     """Checks if the user with the given discord ID is a bot admin or not."""
     return user_id in BOT_ADMINS
+
+
+def is_author_bot_admin(ctx: commands.Context):
+    """Wrapper check function for `is_bot_admin`; checks if the user who invoked the command
+    is a bot admin or not."""
+    userID = ctx.message.author.id
+    return is_bot_admin(userID)
+
 
 def get_realname_from_discordid(user_id: int):
     """Returns the real name of the first user who matches the given ID."""

--- a/bot/main.py
+++ b/bot/main.py
@@ -57,6 +57,8 @@ _PORT_AS_SUFFIX = f":{PORT}" if os.getenv("PORT") else ""
 SUBPATH = os.getenv("SUBPATH")
 BASE_URL = f"{PROTOCOL}://{HOST}{_PORT_AS_SUFFIX}{SUBPATH}"
 
+BOT_ADMINS = [int(id) for id in os.getenv("BOT_ADMINS").split(",") if id != ""]
+
 intent = discord.Intents.default()
 intent.message_content = True
 bot = commands.Bot(command_prefix=".", intents=intent)

--- a/bot/main.py
+++ b/bot/main.py
@@ -90,6 +90,9 @@ def is_verified(user_id: int):
     """Checks if any user with the given ID exists in the DB or not."""
     return True if get_users_from_discordid(user_id) else False
 
+def is_bot_admin(user_id: int):
+    """Checks if the user with the given discord ID is a bot admin or not."""
+    return user_id in BOT_ADMINS
 
 def get_realname_from_discordid(user_id: int):
     """Returns the real name of the first user who matches the given ID."""

--- a/bot/main.py
+++ b/bot/main.py
@@ -15,11 +15,11 @@ This module defines the following functions.
 - `post_verification()`: Handle role add/delete and nickname set post-verification of given user.
 - `verify_user()`: Implements `.verify`.
 - `backend_info()`: Logs server details for debug purposes
-- `is_academic()`: Checks if server is for academic use.
+- `is_academic_or_bot_admin()`: Checks if server is for academic use or if the author is a bot admin.
 - `query()`: Returns user details, uses Discord ID to find in DB.
-- `query_error()`: Replies eror message if server is not academic.
+- `query_error()`: Replies eror message if server is not academic or author is not a bot admin.
 - `roll()`: Returns user details, uses roll number to find in DB.
-- `roll_error()`: Replies eror message if server is not academic.
+- `roll_error()`: Replies eror message if server is not academic or author is not a bot admin.
 - `on_ready()`: Logs a message when the bot joins a server.
 - `main()`: Reads server config, loads DB and starts bot.
 
@@ -284,8 +284,8 @@ def is_academic_or_bot_admin(ctx: commands.Context):
         if not server_configs[ctx.guild.id]["is_academic"] and not is_admin:
             raise CheckFailedException("is_academic_or_bot_admin")
         return True
-    except KeyError:
-        raise CheckFailedException("server_config")
+    except KeyError as err:
+        raise CheckFailedException("server_config") from err
 
 
 @bot.hybrid_command(name="query")

--- a/bot/main.py
+++ b/bot/main.py
@@ -265,8 +265,10 @@ async def backend_info(ctx: commands.Context):
 @backend_info.error
 async def backend_info_error(ctx: commands.Context, error: Exception):
     """If the author of the message is not a bot admin then reply accordingly."""
-    if isinstance(error, CheckFailedException) and \
-        error.check_name == "is_author_bot_admin":
+    if (
+        isinstance(error, CheckFailedException)
+        and error.check_name == "is_author_bot_admin"
+    ):
         author = ctx.message.author
         await ctx.reply(f"{author.mention} is not a bot admin.", ephemeral=True)
     else:
@@ -326,11 +328,16 @@ async def query_error(ctx: commands.Context, error: Exception):
     For the `query` command, if the server is not academic and if the author is
     not a bot admin, replies with an error message.
     """
-    if isinstance(error, CheckFailedException) and error.check_name == "is_academic_or_bot_admin":
+    if (
+        isinstance(error, CheckFailedException)
+        and error.check_name == "is_academic_or_bot_admin"
+    ):
         author = ctx.message.author
-        await ctx.reply("This server is not for academic purposes "
-                        f"and {author.mention} is not a bot admin.",
-                        ephemeral=True)
+        await ctx.reply(
+            "This server is not for academic purposes "
+            f"and {author.mention} is not a bot admin.",
+            ephemeral=True,
+        )
     else:
         await ctx.reply("Some checks failed.", ephemeral=True)
 
@@ -377,10 +384,15 @@ async def roll_error(ctx: commands.Context, error: Exception):
     not a bot admin, replies with an error message.
     """
     author = ctx.message.author
-    if isinstance(error, CheckFailedException) and error.check_name == "is_academic_or_bot_admin":
-        await ctx.reply("This server is not for academic purposes "
-                        f"and {author.mention} is not a bot admin.",
-                        ephemeral=True)
+    if (
+        isinstance(error, CheckFailedException)
+        and error.check_name == "is_academic_or_bot_admin"
+    ):
+        await ctx.reply(
+            "This server is not for academic purposes "
+            f"and {author.mention} is not a bot admin.",
+            ephemeral=True,
+        )
     else:
         await ctx.reply("Some checks failed.", ephemeral=True)
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -6,6 +6,8 @@ This module defines the following functions.
 
 - `get_users_from_discordid()`: Find users from DB given user ID
 - `is_verified()`: If a user is present in DB or not
+- `is_bot_admin()`: If a user is a bot admin or not
+- `is_author_bot_admin()`: If the author of the current message is a bot admin or not
 - `get_realname_from_discordid()`: Get a user's real name from their Discord ID.
 - `send_link()`: Send link for reattempting authentication.
 - `create_roles_if_missing()`: Adds missing roles to a server.

--- a/server_config.ini
+++ b/server_config.ini
@@ -115,3 +115,4 @@ grantroles=Verified
 [Discord-CAS Test Server 2024]
 serverid=1239556898592788520
 grantroles=Verified
+is_academic=yes


### PR DESCRIPTION
I've completed tasks 1, 2, 3 and 5 in this PR. I added functions to check for bot admins, which are to be added in the `.env` file. I've made the `backend_info` command admin-only, and `query` and `roll` can now be run by admins outside the academic server constraint.